### PR TITLE
Quote additional discoveryURLs and scopes

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -33,14 +33,14 @@ export const onRenderBody = (
             function __plugin_google_gapi_init() {
               function __plugin_google_gapi_auth_initClient() {
                 let discoveryURLs = [
-                  '${discoveryURLs.join(",\n                ")}'
+                  '${discoveryURLs.join("',\n                '")}'
                 ]
 
                 let requestedScopes = [
                   'openid',
                   'profile',
                   'email',
-                  '${scopes.join(",\n                ")}'
+                  '${scopes.join("',\n                '")}'
                 ]
 
                 console.debug("Intializing GAPI client...")


### PR DESCRIPTION
fixes #1 

With `gatsby-config.js` content

```js
module.exports = {
  plugins: [
    {
      resolve: `gatsby-plugin-google-gapi`,
      options: {
        apiKey: 'xxx',
        clientId: 'xxx.apps.googleusercontent.com',
        discoveryURLs: [
          "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
          "https://www.example.com/alternative/discovery/"
        ],
        scopes: ["https://www.googleapis.com/auth/drive", 
              "https://www.googleapis.com/auth/photoslibrary.readonly"
      ],
      },
    },
  ]
}
```

`gatsby-ssr.js` creates a script element with content:

```js

            function __plugin_google_gapi_init() {
              function __plugin_google_gapi_auth_initClient() {
                let discoveryURLs = [
                  'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
                'https://www.example.com/alternative/discovery/'
                ]

                let requestedScopes = [
                  'openid',
                  'profile',
                  'email',
                  'https://www.googleapis.com/auth/drive',
                'https://www.googleapis.com/auth/photoslibrary.readonly'
                ]

                console.debug("Intializing GAPI client...")
                gapi.client.init({
                  apiKey: 'xxx',
                  discoveryDocs: discoveryURLs,
                  clientId: 'xxx.apps.googleusercontent.com',
                  scope: requestedScopes.join(' '),
                }).then(() => {
                  console.log('Client initialized...')
                  __plugin_google_gapi_initialized.client = true
                  __plugin_google_gapi_initialized.auth2 = true
                }).catch((error) => {
                  console.log(error)
                })
              }

              console.debug("Intializing GAPI lib...")
              gapi.load('auth2:client', {
                callback: __plugin_google_gapi_auth_initClient,
                onerror: () => {console.error("gapi.load failed")},
              })
              __plugin_google_gapi_init = undefined
            }
```